### PR TITLE
Add banned pairing feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore virtual environment and caches
+myenv/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+.DS_Store

--- a/app.py
+++ b/app.py
@@ -135,17 +135,26 @@ class DrugMatcherApp:
                         )
                     ]
                 )
-        
+
+        def permanent_skip_callback():
+            self.data_manager.add_banned_pairings(drug, matches)
+            # Remove the current drug from the queue
+            if drug in self.not_in_data:
+                self.not_in_data.remove(drug)
+            self.current_index += 1
+            self.process_next(self.current_index)
+
         selector = DrugSelectorGUI(
-            self.root, 
-            drug, 
-            matches, 
-            save_callback, 
-            skip_callback, 
-            exit_callback, 
+            self.root,
+            drug,
+            matches,
+            save_callback,
+            skip_callback,
+            exit_callback,
             back_callback,
             self.current_index,
             len(self.not_in_data),
-            self.save_to_all_matching_drugs
+            self.save_to_all_matching_drugs,
+            permanent_skip_callback
         )
         selector.grab_set()  # Makes the window modal

--- a/data_manager.py
+++ b/data_manager.py
@@ -132,6 +132,11 @@ class DataManager:
         if not self.banned_data.empty:
             banned_capsules = set(self.banned_data['capsule_name'])
             self.not_in_data = [d for d in self.not_in_data if d not in banned_capsules]
+            # Ensure these banned capsules appear in the skipped list
+            existing = {d['capsule_name'] for d in self.skipped_drugs}
+            for capsule in banned_capsules:
+                if capsule not in existing:
+                    self.skipped_drugs.append({'capsule_name': capsule})
 
     def add_banned_pairings(self, capsule_name, matches_df):
         """Record all match options for a capsule drug as permanently skipped."""
@@ -140,6 +145,8 @@ class DataManager:
         new_rows = matches_df[['therapeutic_class', 'pdl_name']].copy()
         new_rows['capsule_name'] = capsule_name
         self.banned_data = pd.concat([self.banned_data, new_rows], ignore_index=True)
+        # Also track the capsule as skipped for this process
+        self.add_skipped_drug(capsule_name)
 
     def remove_last_assignment(self):
         """Remove the last assignment from statuses and state_data, and add the drug back to not_in_data."""

--- a/gui_selector.py
+++ b/gui_selector.py
@@ -16,7 +16,7 @@ class DrugSelectorGUI(Toplevel):
         'button_active_fg': "white"     # White text for button hover
     }
 
-    def __init__(self, master, drug, matches, save_callback, skip_callback, exit_callback, back_callback, current_index, total_drugs, save_to_all_callback=None):
+    def __init__(self, master, drug, matches, save_callback, skip_callback, exit_callback, back_callback, current_index, total_drugs, save_to_all_callback=None, permanent_skip_callback=None):
         super().__init__(master)
         self.title(f"Select Match for {drug}")
 
@@ -31,6 +31,7 @@ class DrugSelectorGUI(Toplevel):
         self.exit_callback = exit_callback
         self.back_callback = back_callback
         self.save_to_all_callback = save_to_all_callback
+        self.permanent_skip_callback = permanent_skip_callback
         self.current_index = current_index
         self.total_drugs = total_drugs
 
@@ -154,8 +155,11 @@ class DrugSelectorGUI(Toplevel):
         btn_skip = ttk.Button(action_frame, text="Skip", command=self.skip_drug, style="TButton")
         btn_skip.grid(row=0, column=2, padx=5, pady=5, sticky="ew")
 
+        btn_perm_skip = ttk.Button(action_frame, text="Permanently Skip", command=self.permanent_skip, style="TButton")
+        btn_perm_skip.grid(row=0, column=3, padx=5, pady=5, sticky="ew")
+
         btn_exit = ttk.Button(action_frame, text="Exit and Save", command=self.exit_program, style="TButton")
-        btn_exit.grid(row=0, column=3, padx=5, pady=5, sticky="ew")
+        btn_exit.grid(row=0, column=4, padx=5, pady=5, sticky="ew")
 
         # Configure grid weights for better spacing
         self.grid_rowconfigure(3, weight=1)  # Make the listbox row expandable
@@ -175,6 +179,7 @@ class DrugSelectorGUI(Toplevel):
         action_frame.columnconfigure(1, weight=1)
         action_frame.columnconfigure(2, weight=1)
         action_frame.columnconfigure(3, weight=1)
+        action_frame.columnconfigure(4, weight=1)
 
     def on_double_click(self, event):
         """Handler for double-click events in the listbox to trigger save functionality."""
@@ -204,6 +209,14 @@ class DrugSelectorGUI(Toplevel):
 
     def skip_drug(self):
         self.skip_callback()
+        try:
+            self.destroy()
+        except tk.TclError:
+            None
+
+    def permanent_skip(self):
+        if self.permanent_skip_callback:
+            self.permanent_skip_callback()
         try:
             self.destroy()
         except tk.TclError:


### PR DESCRIPTION
## Summary
- add root .gitignore
- extend DataManager to load/save banned drug pairings
- track permanently skipped drugs and support filtering them from pairing list
- add `Permanently Skip` feature in GUI with new button
- wire new callback in main app

## Testing
- `python -m py_compile app.py data_manager.py gui_selector.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_685d626bb190832b982a7738594d3840