### PR TITLE
Fix removal of outdated PDL entries

### DIFF
--- a/data_manager.py
+++ b/data_manager.py
@@ -76,10 +76,14 @@ class DataManager:
                         'status': 'Non-Preferred'
                     })
             else:
-                # If the pdl_name isn't found in the PDL dataframe, add to not_in_data for manual processing
-                self.state_data = self.state_data[(self.state_data['therapeutic_class']!=entry['therapeutic_class']) & 
-                                                  (self.state_data['capsule_name']!=entry['capsule_name']) & 
-                                                  (self.state_data['pdl_name']!=entry['pdl_name'])]
+                # If the pdl_name isn't found in the PDL dataframe, remove only
+                # rows with the same therapeutic_class and pdl_name combination
+                # from state_data. Other rows should remain unaffected.
+                mask = ~(
+                    (self.state_data['therapeutic_class'] == entry['therapeutic_class']) &
+                    (self.state_data['pdl_name'] == entry['pdl_name'])
+                )
+                self.state_data = self.state_data[mask]
                 self.not_in_data.append(entry['capsule_name'])
 
         # Remove any banned drugs that may have been added back


### PR DESCRIPTION
## Summary
- refine `process_existing_data` so only the exact `therapeutic_class`/`pdl_name` combination is removed when it is no longer found on the PDL

## Testing
- `python -m py_compile data_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_686e81dfaa9c832b98610caf48e2baf4