### PR TITLE
Fix superscript digits in ME PDL names

### DIFF
--- a/ME/ME.py
+++ b/ME/ME.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import numpy as np
+import re
 
 df = pd.read_excel('ME.xlsx', 'SSDC-PDL_Maine-with-criteria')
 df = df.iloc[16:].reset_index(drop=True)
@@ -12,6 +13,19 @@ df['therapeutic_class'] = df['therapeutic_class'].ffill()
 df = df.melt(id_vars='therapeutic_class', value_vars=['Preferred', 'Non-Preferred'], var_name='status', value_name='pdl_name')
 df = df[['therapeutic_class', 'pdl_name', 'status']]
 df['therapeutic_class'] = df['therapeutic_class'].str.lstrip()
+
+
+def _clean_pdl_name(name: str) -> str:
+    """Remove footnote digits that appear as trailing characters."""
+    if pd.isna(name):
+        return name
+    name = re.sub(r'(?<=[^0-9-])(?:[1-9](?:,[1-9])*)$', '', name).rstrip()
+    name = re.sub(r'(?<=\d{3})\d$', '', name)
+    if re.search(r'(mg|mcg)\d$', name, flags=re.IGNORECASE):
+        name = name[:-1]
+    return name
+
+df['pdl_name'] = df['pdl_name'].astype(str).apply(_clean_pdl_name)
 
 df = df.dropna(subset=['pdl_name'])
 df = df.sort_values('therapeutic_class').reset_index(drop=True)


### PR DESCRIPTION
## Summary
- clean trailing footnote numbers from `pdl_name` when generating the Maine PDL CSV

## Testing
- `pytest archive/test.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686fc9659568832b9dc17d7eb259e920